### PR TITLE
Show DLC names while copying manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Easily create lua and manifest for SteamTools from your installed Steam games!
 * Reads local `config.vdf` for depot decryption keys.
 * Skips DLC or language-only depots when no key is available.
 * Copies available manifest files into a dedicated output folder.
+* Displays DLC names when extracting manifest files (e.g. `Game - DLC`).
 * Generates a Lua file (`<APPID>.lua`) containing:
 
   * `addappid(appID)`


### PR DESCRIPTION
## Summary
- include depot names in `extract_depots`
- print `AppName - DLCName` when copying manifest files
- update Lua writer for new depot structure
- document DLC name extraction in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6888d6cdebdc83319e5adcf6b99cda67