### PR TITLE
Show manifest names when copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Easily create lua and manifest for SteamTools from your installed Steam games!
 * Extracts depot IDs and public manifest GIDs.
 * Reads local `config.vdf` for depot decryption keys.
 * Skips DLC or language-only depots when no key is available.
-* Copies available manifest files into a dedicated output folder.
+* Copies available manifest files into a dedicated output folder, displaying the
+  friendly manifest (e.g. DLC) name when available.
 * Generates a Lua file (`<APPID>.lua`) containing:
 
   * `addappid(appID)`


### PR DESCRIPTION
## Summary
- show manifest names when copying
- mention this in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6888dfec8bb48331bac281a1df1b4ce6