### PR TITLE
Add DLC depot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Easily create lua and manifest for SteamTools from your installed Steam games!
 * Fetches Steam app metadata (VDF format) via **SteamCMD**.
 * Extracts depot IDs and public manifest GIDs.
 * Reads local `config.vdf` for depot decryption keys.
-* Skips DLC or language-only depots when no key is available.
+* Automatically processes DLC depots, skipping those without decryption keys.
 * Copies available manifest files into a dedicated output folder.
 * Generates a Lua file (`<APPID>.lua`) containing:
 


### PR DESCRIPTION
## Summary
- extend `main.py` to parse DLC app ids and include their depots
- update Lua generation to list DLC appids
- document new DLC handling in README

## Testing
- `python -m py_compile main.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'winreg')*

------
https://chatgpt.com/codex/tasks/task_e_6888e39ffefc833181e760ea3f7e8467